### PR TITLE
Update Gradle wrapper to version 8.14.3

### DIFF
--- a/software/gradle/wrapper/gradle-wrapper.properties
+++ b/software/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Updated gradle-wrapper.properties to use Gradle 8.14.3
- Tested build compatibility with new version
- Build successful with no breaking changes