### PR TITLE
Update FlatLaf to version 3.6.1

### DIFF
--- a/software/build.gradle.kts
+++ b/software/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
     implementation("com.fazecast:jSerialComm:2.9.3")
     
     // FlatLaf Look and Feel
-    implementation("com.formdev:flatlaf:3.2.5")
-    implementation("com.formdev:flatlaf-extras:3.2.5")
+    implementation("com.formdev:flatlaf:3.6.1")
+    implementation("com.formdev:flatlaf-extras:3.6.1")
     
     // Logging
     implementation("org.apache.logging.log4j:log4j-core:2.20.0")


### PR DESCRIPTION
- Updated com.formdev:flatlaf from 3.2.5 to 3.6.1
- Updated com.formdev:flatlaf-extras from 3.2.5 to 3.6.1
- Build and JAR creation tested successfully
- No breaking changes detected
- Maintains modern UI appearance and functionality