### PR TITLE
Update Log4j to version 2.25.2

### DIFF
--- a/software/build.gradle.kts
+++ b/software/build.gradle.kts
@@ -29,9 +29,9 @@ dependencies {
     implementation("com.formdev:flatlaf-extras:3.6.1")
     
     // Logging
-    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
-    implementation("org.apache.logging.log4j:log4j-api:2.20.0")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.20.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.25.2")
+    implementation("org.apache.logging.log4j:log4j-api:2.25.2")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.25.2")
     
     // Testing
     testImplementation("org.jetbrains.kotlin:kotlin-test")


### PR DESCRIPTION
- Updated org.apache.logging.log4j:log4j-core from 2.20.0 to 2.25.2
- Updated org.apache.logging.log4j:log4j-api from 2.20.0 to 2.25.2
- Updated org.apache.logging.log4j:log4j-slf4j-impl from 2.20.0 to 2.25.2
- Build and JAR creation tested successfully
- No breaking changes detected
- Includes latest security fixes and performance improvements