### PR TITLE
Implement dynamic date-based version numbering

### DIFF
--- a/software/build.gradle.kts
+++ b/software/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.text.SimpleDateFormat
+import java.util.Date
 
 plugins {
     kotlin("jvm") version "2.2.20"
@@ -7,7 +9,7 @@ plugins {
 }
 
 group = "io.github.kolod"
-version = "1.0.0"
+version = SimpleDateFormat("yy.M.d").format(Date())
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
- Added SimpleDateFormat and Date imports to build.gradle.kts
- Changed version from static '1.0.0' to SimpleDateFormat('yy.M.d').format(Date())
- Version now automatically reflects build date (e.g., 25.9.30 for Sep 30, 2025)
- Build and JAR creation tested successfully
- Provides automatic versioning without manual updates