### PR TITLE
Implement Shadow JAR plugin for fat JAR creation

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -35,7 +35,10 @@ A Kotlin desktop application for reading ROM chips via serial port communication
 # Run the application
 ./gradlew run
 
-# Create a fat JAR
+# Create a fat JAR with all dependencies (recommended)
+./gradlew shadowJar
+
+# Create a standard JAR (requires classpath)
 ./gradlew jar
 ```
 
@@ -48,7 +51,10 @@ gradlew.bat build
 # Run the application
 gradlew.bat run
 
-# Create a fat JAR
+# Create a fat JAR with all dependencies (recommended)
+gradlew.bat shadowJar
+
+# Create a standard JAR (requires classpath)
 gradlew.bat jar
 ```
 
@@ -68,6 +74,26 @@ gradlew.bat jar
    - Select a HEX file containing expected data
    - Click "VERIFY" to read ROM data and compare with the file
    - Differences will be highlighted in the hex viewer
+
+## Deployment
+
+### Fat JAR (Recommended)
+The application uses the Shadow JAR plugin to create a self-contained executable JAR:
+
+```bash
+# Build the fat JAR
+./gradlew shadowJar
+
+# The JAR will be created in build/libs/
+# Run with: java -jar build/libs/rom-reader-<version>.jar
+```
+
+**Benefits of Shadow JAR:**
+- ✅ All dependencies included in a single JAR file
+- ✅ No classpath configuration required
+- ✅ Easy distribution and deployment
+- ✅ Minimized JAR size (unused classes removed)
+- ✅ Cross-platform compatibility
 
 ## Serial Communication Protocol
 
@@ -116,6 +142,7 @@ src/
 - **jSerialComm**: Serial port communication library
 - **FlatLaf**: Modern look and feel
 - **Log4j2**: Logging framework
+- **Shadow JAR**: Fat JAR creation plugin
 - **JUnit**: Testing framework
 
 ## License

--- a/software/build.gradle.kts
+++ b/software/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import java.text.SimpleDateFormat
 import java.util.Date
 
 plugins {
     kotlin("jvm") version "2.2.20"
     application
+    id("com.gradleup.shadow") version "8.3.8"
     id("org.openjfx.javafxplugin") version "0.0.13" apply false
 }
 
@@ -55,10 +57,24 @@ tasks.test {
     useJUnit()
 }
 
-tasks.jar {
+tasks.withType<ShadowJar> {
+    archiveBaseName.set("rom-reader")
+    archiveClassifier.set("")
     manifest {
         attributes["Main-Class"] = "io.github.kolod.RomReaderKt"
     }
-    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    minimize()
+}
+
+// Configure application plugin to use shadow jar
+tasks.named("distZip") {
+    dependsOn("shadowJar")
+}
+
+tasks.named("distTar") {
+    dependsOn("shadowJar")  
+}
+
+tasks.named("startScripts") {
+    dependsOn("shadowJar")
 }


### PR DESCRIPTION
- Added com.gradleup.shadow plugin version 8.3.8
- Added ShadowJar import for proper task configuration
- Replaced manual JAR task with Shadow JAR configuration
- Set archiveBaseName to 'rom-reader' and removed classifier
- Enabled JAR minimization for smaller file size
- Fixed task dependencies for distZip, distTar, and startScripts
- Updated README.md with Shadow JAR information and commands
- Added deployment section explaining fat JAR benefits
- Build and shadowJar tasks tested successfully
- Generated fat JAR includes all dependencies (~3MB)